### PR TITLE
Using ImageStream java:8

### DIFF
--- a/widget-factory/.applier/templates/build.yml
+++ b/widget-factory/.applier/templates/build.yml
@@ -39,7 +39,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: java:latest
+          name: java:8
           namespace: openshift
       type: Source
 parameters:


### PR DESCRIPTION
on Java 9+ , the deployment for the app will fail because JAX-B is not present.

It will fail with the error:

`2020-05-13 00:33:54.239 ERROR 1 --- [           main] o.s.boot.SpringApplication               : Application run failed
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: Invocation of init method failed; nested exception is java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException
Caused by: java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException`